### PR TITLE
Quick fix of logo 

### DIFF
--- a/app.R
+++ b/app.R
@@ -81,7 +81,7 @@ ui <- fluidPage(
     )
   ),
   titlePanel(tagList(
-    img(src = "img/logo-loqui.jpeg", height = "45px"),
+    img(src = "i/img/logo-loqui.jpeg", height = "45px"),
     "Loqui",
     span(
       actionButton("demo",


### PR DESCRIPTION
I noticed that the recently added logo file was not being rendered:

https://github.com/FredHutch/loqui/blob/f578bf5221c5dd7debd173de5ad5e7b8d09e1744/app.R#L84

I fixed this bug by adding `i/` to the front of the image path.