### PR TITLE
expose group var GITHUB_PAT inside build container

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ build:
   script:
     - mkdir -p .secrets
     - echo $GOOGLE_TOKEN | base64 -d > .secrets/$GOOGLE_TOKEN_NAME
-    - docker build --no-cache --build-arg CACHEBUST=$(date +%s) -t sc-registry.fredhutch.org/loqui:test .
+    - docker build --no-cache --build-arg GITHUB_PAT=${GITHUB_PAT} --build-arg CACHEBUST=$(date +%s) -t sc-registry.fredhutch.org/loqui:test .
     - docker push sc-registry.fredhutch.org/loqui:test
 
 test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM fredhutch/r-shiny-base:4.4.0
 
+ARG GITHUB_PAT
+
 RUN echo break cache0
 RUN apt-get --allow-releaseinfo-change update -y
 


### PR DESCRIPTION
so that we can have authenticated github requests
this will reduce errors with remotes::install_github()

I saw errors like this in the build:

```
3 ERROR: executor failed running [/bin/sh -c R -e 'remotes::install_github("jhudsl/text2speech", upgrade = "never")']: exit code: 1
------
 > [18/30] RUN R -e 'remotes::install_github("jhudsl/text2speech", upgrade = "never")':
0.929   HTTP error 403.
0.929   API rate limit exceeded for 140.107.222.244. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
0.929 
0.929   Rate limit remaining: 0/60
0.929   Rate limit reset at: 2024-07-30 19:19:44 UTC
0.929 
0.929   To increase your GitHub API rate limit
0.929   - Use `usethis::create_github_token()` to create a Personal Access Token.
0.929   - Use `gitcreds::gitcreds_set()` to add the token.
0.929 Execution halted
```

This would fix those. GITHUB_PAT is set in the CI/CD build environment, this would make it visible in the container where the app is built.
