### PR TITLE
add checkboxes for speaker notes and link sharing

### DIFF
--- a/app.R
+++ b/app.R
@@ -253,17 +253,13 @@ server <- function(input, output, session) {
   # Show different inputs depending on Google Slides or PowerPoint
   output$user_input <- renderUI({
     if (input$presentation_tool == "google_slides") {
-      div(
+      tagList(
         textInput("gs_url",
                   label = "Google Slides URL (Enable Link Sharing)",
                   placeholder = "Paste a Google Slides URL"),
-        style = "font-size:18px"
-        ),
-      div(
         checkboxInput("link_sharing_check",
                       label = "Link Sharing has been enabled",
-                      value = FALSE),
-        style = "font-size:18px"
+                      value = FALSE)
       )
     } else {
       fileInput("pptx_file", NULL, accept = ".pptx",

--- a/app.R
+++ b/app.R
@@ -211,7 +211,7 @@ server <- function(input, output, session) {
   observe({
     shinyjs::toggleState("generate",
                          !is.null(input$email) && input$email != "" && is_valid_email(input$email) &&
-                         speaker_ntoes_check == TRUE &&
+                         speaker_notes_check == TRUE &&
                            ((!inherits(try(gsplyr::download(input$gs_url, type = "pptx"), silent = TRUE), "try-error") &&
                            link_sharing_check == TRUE) ||
                               is.data.frame(input$pptx_file)))

--- a/app.R
+++ b/app.R
@@ -211,9 +211,9 @@ server <- function(input, output, session) {
   observe({
     shinyjs::toggleState("generate",
                          !is.null(input$email) && input$email != "" && is_valid_email(input$email) &&
-                         speaker_notes_check == TRUE &&
+                         input$speaker_notes_check == TRUE &&
                            ((!inherits(try(gsplyr::download(input$gs_url, type = "pptx"), silent = TRUE), "try-error") &&
-                           link_sharing_check == TRUE) ||
+                           input$link_sharing_check == TRUE) ||
                               is.data.frame(input$pptx_file)))
     shinyjs::toggleState("download_btn",
                          !is.null(input$email) && input$email != "" && is_valid_email(input$email) &&


### PR DESCRIPTION
Uses the checkboxInput function to add checkboxes (https://shiny.posit.co/r/components/inputs/checkbox/) to have users confirm that they have speaker notes for every slide (whether google slides or powerpoint), and to confirm that they have link sharing on if google slides. Additionally, a check is done to make sure both (when applicable) checkboxes are checked to allow the buttons to be available to push.

Relevant changes in the code are 
- speaker notes checkbox: https://github.com/FredHutch/loqui/blob/fbc71f7b69645f4e525d6f0c8900c8bc2f6d3256/app.R#L145-L149
- link sharing checkbox for just google slides input: https://github.com/FredHutch/loqui/blob/fbc71f7b69645f4e525d6f0c8900c8bc2f6d3256/app.R#L254-L263
- verifying that relevant checkboxes are checked: https://github.com/FredHutch/loqui/blob/fbc71f7b69645f4e525d6f0c8900c8bc2f6d3256/app.R#L212-L217
(note by relevant I mean that link sharing is only considered if dealing with google slides/not pptx, while speaker notes checkbox is always considered)

Used this doc to identify/use tagList() within renderUI to get the checks to pass: https://shiny.posit.co/r/reference/shiny/latest/renderui.html

Have been able to run this locally now and have included screenshots of the behavior/look.